### PR TITLE
Fix x-label duplication in Matlab plot

### DIFF
--- a/Matlab/Fitting_sigmoid.m
+++ b/Matlab/Fitting_sigmoid.m
@@ -21,7 +21,6 @@ figure(4);
 plot(10*log10(x), Accuracies, 'bo', 'DisplayName', 'Numerical Calculation');
 hold on;
 plot(10*log10(x), fitted_values, 'r-', 'LineWidth', 2, 'DisplayName', 'Fitted Logistic Curve');
-xlabel('Physical scaling parameter F (dB)');
 xlabel('Physical scaling parameter $F$ (dB)', 'Interpreter', 'latex', 'FontSize', 14)
 
 ylabel('Classification Accuracy (%)');


### PR DESCRIPTION
## Summary
- remove redundant plain-text `xlabel` call from `Fitting_sigmoid.m`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e49955cc83219fe6f6810df6883d