### PR TITLE
Add accuracy utility and tests

### DIFF
--- a/Python/utils.py
+++ b/Python/utils.py
@@ -1,0 +1,71 @@
+try:
+    import torch
+    TORCH_AVAILABLE = True
+except ImportError:  # Torch may not be available in minimal environments
+    torch = None
+    TORCH_AVAILABLE = False
+
+
+def calculate_accuracy(loader, model, secure=False, printprogress=False):
+    """Compute classification accuracy.
+
+    Parameters
+    ----------
+    loader : iterable
+        Iterable yielding ``(images, labels)`` pairs.
+    model : object
+        Model callable returning network outputs. It should expose
+        ``eval`` and ``train`` methods.
+    secure : bool, optional
+        If ``True``, the model returns ``(outputs, PDmeans, PDrealized)``
+        and these values are collected and returned.
+    printprogress : bool, optional
+        If ``True``, progress information is printed while processing
+        the loader.
+    """
+
+    model.eval()
+    correct = 0
+    total = 0
+
+    if secure:
+        PDmeansarr = []
+        PDrealizedarr = []
+
+    if TORCH_AVAILABLE:
+        context = torch.no_grad()
+    else:
+        class _NoGrad:
+            def __enter__(self):
+                pass
+            def __exit__(self, exc_type, exc, tb):
+                pass
+        context = _NoGrad()
+
+    with context:
+        for images, labels in loader:
+            if not secure:
+                outputs = model(images)
+            else:
+                outputs, PDmeans, PDrealized = model(images)
+                PDmeansarr.append(PDmeans)
+                PDrealizedarr.append(PDrealized)
+
+            if TORCH_AVAILABLE:
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+            else:
+                predicted = [max(range(len(o)), key=o.__getitem__) for o in outputs]
+                total += len(labels)
+                correct += sum(int(p == l) for p, l in zip(predicted, labels))
+
+            if printprogress:
+                print(f"{total} test batches done")
+
+    model.train()
+
+    if not secure:
+        return 100 * correct / total
+    else:
+        return 100 * correct / total, PDmeansarr, PDrealizedarr

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Quantum-secure-multiparty-deep-learning
 https://arxiv.org/abs/2408.05629
+
+Run tests using `python -m unittest`.

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,0 +1,37 @@
+import unittest
+
+from Python.utils import calculate_accuracy
+
+
+class DummyModel:
+    def __init__(self, outputs):
+        self.outputs = list(outputs)
+
+    def eval(self):
+        pass
+
+    def train(self):
+        pass
+
+    def __call__(self, images):
+        return self.outputs.pop(0)
+
+
+class TestCalculateAccuracy(unittest.TestCase):
+    def test_accuracy_simple(self):
+        # Two batches with two samples each
+        loader = [
+            (None, [0, 1]),
+            (None, [0, 1])
+        ]
+        outputs = [
+            [[10, 1], [1, 10]],  # predicts [0,1] -> 2 correct
+            [[1, 10], [1, 10]]   # predicts [1,1] -> 1 correct
+        ]
+        model = DummyModel(outputs)
+        acc = calculate_accuracy(loader, model)
+        self.assertEqual(acc, 75.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `calculate_accuracy` in `Python/utils.py`
- create unittest for accuracy computation
- mention `python -m unittest` in README

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6871e49b9d108321b9507635c3124a3c